### PR TITLE
README: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ information about Phabulous.
 To compile Phabulous, you need a recent version of Go:
 
 ```
-go get github.com/etcinit/phabulous
+go get github.com/etcinit/phabulous/cmd/phabulous
 
 // or, for cross-compiling:
 


### PR DESCRIPTION
The current instructions are incorrect as-is because the repository root no longer contains Go source files. To download and install, you must specify the `github.com/etcinit/phabulous/cmd/phabulous` package.

Fixes:

```
$ go get github.com/etcinit/phabulous
package github.com/etcinit/phabulous: no buildable Go source files in /home/peggy/go/src/github.com/etcinit/phabulous

$ go get github.com/etcinit/phabulous/cmd/phabulous

$ phabulous
Usage: phabulous [global options] command [command options] [arguments...]
```