### PR TITLE
Fix action signature

### DIFF
--- a/cmd/phabulous/phabulous.go
+++ b/cmd/phabulous/phabulous.go
@@ -52,11 +52,12 @@ func main() {
 
 	// Setup the default action. This action will be triggered when no
 	// subcommand is provided as an argument
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) error {
 		fmt.Println(
 			"Usage: phabulous [global options] command [command options] " +
 				"[arguments...]",
 		)
+		return nil
 	}
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
> DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature