### PR TITLE
Make colon in @mention optional

### DIFF
--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -49,7 +49,7 @@ type Bot struct {
 func (b *Bot) mentionRegex(contents string) *regexp.Regexp {
 	username := b.slackInfo.User.ID
 
-	return regexp.MustCompile("^<@" + username + ">: " + contents + "$")
+	return regexp.MustCompile("^<@" + username + ">:? " + contents + "$")
 }
 
 func (b *Bot) loadHandlers() {


### PR DESCRIPTION
It seems like Slack just change the behavior of tab-completing an
@mention to not include the colon.

Typing `@phab<TAB>` now results in `@phabulous ` instead of the previous
behavior of `@phabulous: `. For convenience and compatibility, support
both.