### PR TITLE
Extract members from project reviewers in summon

### DIFF
--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -49,14 +49,14 @@ type Bot struct {
 func (b *Bot) mentionRegex(contents string) *regexp.Regexp {
 	username := b.slackInfo.User.ID
 
-	return regexp.MustCompile("^<@" + username + ">:? " + contents + "$")
+	return regexp.MustCompile("^<@" + username + ">:?\\s+" + contents + "$")
 }
 
 func (b *Bot) loadHandlers() {
 	b.handlers = map[*regexp.Regexp]func(*slack.MessageEvent, []string){}
 	b.imHandlers = map[*regexp.Regexp]func(*slack.MessageEvent, []string){}
 
-	b.imHandlers[regexp.MustCompile("^lookup ([T|D][0-9]{1,16})$")] =
+	b.imHandlers[regexp.MustCompile("^lookup\\s+([T|D][0-9]{1,16})$")] =
 		b.HandleLookup
 	b.imHandlers[regexp.MustCompile("^([T|D][0-9]{1,16})$")] =
 		b.HandleLookup
@@ -65,14 +65,14 @@ func (b *Bot) loadHandlers() {
 	b.imHandlers[regexp.MustCompile("dev:post:feed:test")] =
 		b.HandleTestFeedMessage
 
-	b.handlers[b.mentionRegex("summon D([0-9]{1,16})")] =
+	b.handlers[b.mentionRegex("summon\\s+D([0-9]{1,16})")] =
 		b.HandleSummon
 	b.handlers[b.mentionRegex("help")] = b.HandleHelp
 	b.handlers[b.mentionRegex("([T|D][0-9]{1,16})")] = b.HandleLookup
-	b.handlers[b.mentionRegex("lookup ([T|D][0-9]{1,16})")] = b.HandleLookup
+	b.handlers[b.mentionRegex("lookup\\s+([T|D][0-9]{1,16})")] = b.HandleLookup
 	b.handlers[regexp.MustCompile("^([T|D][0-9]{1,16})$")] = b.HandleLookup
 	b.handlers[regexp.MustCompile(
-		"meme ([^ ]{1,128}) \"(.{1,128})\" \"(.{1,128})\"$",
+		"meme\\+([^ ]{1,128})\\s+\"(.{1,128})\"\\s+\"(.{1,128})\"$",
 	)] = b.HandleCreateMeme
 }
 

--- a/app/bot/bot_help.go
+++ b/app/bot/bot_help.go
@@ -23,7 +23,7 @@ func (b *Bot) HandleHelp(ev *slack.MessageEvent, matches []string) {
     *summon Dxxx* (channel): Asks reviewers of a revision to review it.
     *lookup Txxx* (channel, DM): Looks up a task by its number.
     *lookup Dxxx* (channel, DM): Looks up a revision by its number.
-	*meme <macro> "upper" "lower"* (channel): Generates a meme using the macro.
+    *meme <macro> "upper" "lower"* (channel): Generates a meme using the macro.
     *help* (channel, DM): Shows this help.`,
 		messages.IconTasks,
 		true,

--- a/app/bot/bot_summon.go
+++ b/app/bot/bot_summon.go
@@ -65,6 +65,7 @@ func (b *Bot) HandleSummon(ev *slack.MessageEvent, matches []string) {
 		return
 	}
 
+	authorPHID := (*res)[0].AuthorPHID
 	reviewerMap := map[string]bool{}
 
 	for _, reviewerPHID := range (*res)[0].Reviewers {
@@ -91,7 +92,9 @@ func (b *Bot) HandleSummon(ev *slack.MessageEvent, matches []string) {
 					return
 				}
 				for _, member := range res {
-					reviewerMap["@"+member.Name] = true
+					if member.PHID != authorPHID {
+						reviewerMap["@"+member.Name] = true
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
If a Differential has project reviewers, query the project and extract
the individual members to use for the summon message.