### PR TITLE
fix(conduit): Fix parameter name for `phabulous.toslack` conduit call

### DIFF
--- a/app/gonduit/extensions/requests/phabulous_toslack.go
+++ b/app/gonduit/extensions/requests/phabulous_toslack.go
@@ -4,6 +4,6 @@ import "github.com/etcinit/gonduit/requests"
 
 // PhabulousToSlackRequest represets a request to phabulous.toslack.
 type PhabulousToSlackRequest struct {
-	UserPHIDs []string `json:"userPHIDs"`
+	UserPHIDs []string `json:"UserPHIDs"`
 	requests.Request
 }


### PR DESCRIPTION
The call was failing for me because there was a mismatch in the Conduit parameter. I'm not sure if it makes more sense to make this `UserPHIDs` or to change the parameter in the Conduit plugin to be `userPHIDs`.

Unfortunately, it seems like the Chromabits instance of Phabricator is full right now, so I wasn't able to put up a revision there. Feel free to close this if you think it makes sense in the libphutil extension.