### PR TITLE
Added listtasks command to list open tasks for a user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 main.production.yml
 dist
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,5 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 go:
-  - 1.5
-  - 1.6
   - 1.7
+  - 1.8

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ information about Phabulous.
 
 ## Compiling from source
 
-To compile Phabulous, you need a recent version of Go:
+To compile Phabulous, you need a recent version of Go (>= 1.7):
 
 ```
 go get github.com/etcinit/phabulous/cmd/phabulous

--- a/app/connectors/irc_bot_test.go
+++ b/app/connectors/irc_bot_test.go
@@ -12,12 +12,13 @@ import (
 
 func Test_IRCConnector_LoadModules(t *testing.T) {
 	connector := IRCConnector{}
-	connector.LoadModules([]interfaces.Module{&core.Module{}})
+	connector.LoadModules([]interfaces.Module{&core.Module{Config:connector.config}})
+	connector.config = confer.NewConfig()
 
 	assert.Equal(t, 0, len(connector.GetHandlers()))
 	assert.Equal(t, 0, len(connector.GetIMHandlers()))
 
-	modules := []interfaces.Module{&core.Module{}}
+	modules := []interfaces.Module{&core.Module{Config:connector.config}}
 
 	connector.client = client.SimpleClient("phabulous")
 	connector.LoadModules(modules)

--- a/app/gonduit/extensions/requests/phabulous_toslack.go
+++ b/app/gonduit/extensions/requests/phabulous_toslack.go
@@ -4,6 +4,6 @@ import "github.com/etcinit/gonduit/requests"
 
 // PhabulousToSlackRequest represets a request to phabulous.toslack.
 type PhabulousToSlackRequest struct {
-	UserPHIDs []string `json:"userPHIDs"`
+	UserPHIDs []string `json:"UserPHIDs"`
 	requests.Request
 }

--- a/app/modules/core/command_lookup_test.go
+++ b/app/modules/core/command_lookup_test.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_additionalMatchersNil(t *testing.T) {
+	lookup_command := LookupCommand{AdditionalMatchers: nil}
+	assert.NotEmpty(t, lookup_command.GetMatchers())
+}
+
+func Test_additionalMatchers(t *testing.T) {
+	additionalMatchers := []string{"([D][0-9]{1,16})", "([D][0-1]{1,16})"}
+	lookupCommand := LookupCommand{AdditionalMatchers: additionalMatchers}
+	assert.Contains(t, lookupCommand.GetMatchers(), "([D][0-9]{1,16})")
+	assert.Contains(t, lookupCommand.GetMatchers(), "([D][0-1]{1,16})")
+}

--- a/app/modules/core/command_task.go
+++ b/app/modules/core/command_task.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/etcinit/gonduit/constants"
+	"github.com/etcinit/gonduit/requests"
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/etcinit/phabulous/app/messages"
+)
+
+// TaskCommand lists your tasks
+type TaskCommand struct{}
+
+// GetUsage .
+func (c *TaskCommand) GetUsage() string {
+	return "listtasks <username>"
+}
+
+// GetDescription .
+func (c *TaskCommand) GetDescription() string {
+	return "Lists currently-open tasks for a given Phabricator user. If no username is provided, Slack username is used."
+}
+
+// GetMatchers .
+func (c *TaskCommand) GetMatchers() []string {
+	return []string{
+		"^listtasks\\s*(.*)$",
+	}
+}
+
+// GetIMMatchers .
+func (c *TaskCommand) GetIMMatchers() []string {
+	return []string{
+		"^listtasks\\s*(.*)$",
+	}
+}
+
+// GetMentionMatchers returns the channel mention matchers for this command.
+func (c *TaskCommand) GetMentionMatchers() []string {
+	return []string{
+		"^listtasks\\s*(.*)$",
+	}
+}
+
+// GetHandler -- returns a handler that mostly ignores what was
+// matched and just returns the user's list of open tasks.
+func (c *TaskCommand) GetHandler() interfaces.Handler {
+	return func(s interfaces.Bot, m interfaces.Message, matches []string) {
+		s.StartTyping(m.GetChannel())
+
+		conn, err := s.GetGonduit()
+		if err != nil {
+			s.Excuse(m, err)
+			return
+		}
+
+		username := matches[1]
+		if len(username) == 0 {
+			username, err = s.GetUsername(m.GetUserID())
+			if err != nil || username == "" {
+				s.Excuse(m, err)
+				return
+			}
+		}
+		nameres, err := conn.UserQuery(
+			requests.UserQueryRequest{Usernames: []string{username}},
+		)
+		if err != nil || nameres == nil || len(*nameres) == 0 {
+			message := fmt.Sprintf(`
+Couldn't find Phabricator user for Slack username *@%s*. Typically
+this means your Slack username doesn't match your Phabricator
+username.
+			`,
+				username,
+			)
+			s.Post(
+				m.GetChannel(),
+				message,
+				messages.IconDefault,
+				true,
+			)
+			return
+		}
+		ownerPHID := (*nameres)[0].PHID
+
+		res, err := conn.ManiphestQuery(requests.ManiphestQueryRequest{
+			OwnerPHIDs: []string{ownerPHID},
+			Status:     constants.ManiphestTaskStatusOpen,
+			Order:      constants.ManiphestQueryOrderPriority,
+		})
+
+		if err != nil {
+			s.Excuse(m, err)
+			return
+		}
+
+		if res == nil {
+			s.Post(
+				m.GetChannel(),
+				fmt.Sprintf("<@%s> doesn't appear to have any open tasks", username),
+				messages.IconDefault,
+				true,
+			)
+			return
+		}
+
+		var buffer bytes.Buffer
+		for _, value := range *res {
+			buffer.WriteString(
+				fmt.Sprintf("*<%s|T%s>* -- %v\n", value.URI, value.ID, value.Title),
+			)
+		}
+		s.Post(
+			m.GetChannel(),
+			buffer.String(),
+			messages.IconTasks,
+			true,
+		)
+	}
+}

--- a/app/modules/core/module.go
+++ b/app/modules/core/module.go
@@ -1,9 +1,14 @@
 package core
 
-import "github.com/etcinit/phabulous/app/interfaces"
+import (
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/jacobstr/confer"
+)
 
 // Module provides development/debugging commands.
-type Module struct{}
+type Module struct{
+	Config *confer.Config
+}
 
 // GetName returns the name of this module.
 func (m *Module) GetName() string {
@@ -12,8 +17,13 @@ func (m *Module) GetName() string {
 
 // GetCommands returns the commands provided by this module.
 func (m *Module) GetCommands() []interfaces.Command {
+	var lookupCommandAdditionalMatchers []string
+	if m.Config.InConfig("commands.lookup.matchers") {
+		lookupCommandAdditionalMatchers = m.Config.GetStringSlice("commands.lookup.matchers")
+	}
 	return []interfaces.Command{
-		&LookupCommand{},
+
+		&LookupCommand{AdditionalMatchers:lookupCommandAdditionalMatchers},
 		&SummonCommand{},
 		&MemeCommand{},
 		&ModulesCommand{},

--- a/app/modules/core/module.go
+++ b/app/modules/core/module.go
@@ -28,5 +28,6 @@ func (m *Module) GetCommands() []interfaces.Command {
 		&MemeCommand{},
 		&ModulesCommand{},
 		&HelpCommand{},
+		&TaskCommand{},
 	}
 }

--- a/app/modules/dev/module.go
+++ b/app/modules/dev/module.go
@@ -1,9 +1,14 @@
 package dev
 
-import "github.com/etcinit/phabulous/app/interfaces"
+import (
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/jacobstr/confer"
+)
 
 // Module provides development/debugging commands.
-type Module struct{}
+type Module struct{
+	Config *confer.Config
+}
 
 // GetName returns the name of this module.
 func (m *Module) GetName() string {

--- a/app/modules/extension/module.go
+++ b/app/modules/extension/module.go
@@ -1,9 +1,14 @@
 package extension
 
-import "github.com/etcinit/phabulous/app/interfaces"
+import (
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/jacobstr/confer"
+)
 
 // Module provides development/debugging commands.
-type Module struct{}
+type Module struct{
+	Config *confer.Config
+}
 
 // GetName returns the name of this module.
 func (m *Module) GetName() string {

--- a/app/modules/factory.go
+++ b/app/modules/factory.go
@@ -42,11 +42,11 @@ func (f *ModuleFactory) Make() []interfaces.Module {
 		}
 
 		if moduleName == "core" {
-			moduleMap["core"] = &core.Module{}
+			moduleMap["core"] = &core.Module{f.config}
 		} else if moduleName == "dev" {
-			moduleMap["dev"] = &dev.Module{}
+			moduleMap["dev"] = &dev.Module{f.config}
 		} else if moduleName == "extension" {
-			moduleMap["extension"] = &extension.Module{}
+			moduleMap["extension"] = &extension.Module{f.config}
 		} else {
 			f.logger.Panicf(
 				"Unable to load modules. Unknown module '%s'.",

--- a/app/modules/utilities/listutil.go
+++ b/app/modules/utilities/listutil.go
@@ -1,0 +1,32 @@
+package utilities
+
+func UniqueItemsOf(s []string) []string {
+	unique := make(map[string]bool, len(s))
+	uniques := make([]string, len(unique))
+	for _, elem := range s {
+		if len(elem) != 0 {
+			if !unique[elem] {
+				uniques = append(uniques, elem)
+				unique[elem] = true
+			}
+		}
+	}
+	return uniques
+}
+
+func Contains(slice1 []string, slice2 []string) bool {
+	slice1Uniques := UniqueItemsOf(slice1)
+	slice2Uniques := UniqueItemsOf(slice2)
+	for _, value2 := range slice2Uniques {
+		var slice2ItemInSlice1 = false
+		for _, value1 := range slice1Uniques {
+			if value1 == value2 {
+				slice2ItemInSlice1 = true
+			}
+		}
+		if !slice2ItemInSlice1 {
+			return false
+		}
+	}
+	return true
+}

--- a/config/main.yml
+++ b/config/main.yml
@@ -45,7 +45,7 @@ slack:
   # When set to false, the bot will post like any other integration (like
   # webhooks). This allows it to post on almost any channel without having to
   # be invited.
-  as-user: true
+  as-user: false
 irc:
   # Use this flag to enable/disable the IRC connector.
   enable: false
@@ -105,3 +105,9 @@ core:
     includeSelf: true
 misc:
   ignore-ca: false
+
+commands:
+  lookup:
+    # override set of REGEXes used by lookup commands
+    matchers:
+      - ([T|D][0-9]{1,16})+


### PR DESCRIPTION
'listtasks' command has the following properties:

1. Takes Phabricator username as input and displays the currently open tasks for that user. 
2. If no username is provided, their Slack username is used to look up tasks (assumption being that their Slack username matches their Phabricator username). 
3. If username is not found, an error message is displayed.