### PR TITLE
issue 59 - POC override default REGExes used by core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 main.production.yml
 dist
+.idea

--- a/app/connectors/irc_bot_test.go
+++ b/app/connectors/irc_bot_test.go
@@ -12,12 +12,13 @@ import (
 
 func Test_IRCConnector_LoadModules(t *testing.T) {
 	connector := IRCConnector{}
-	connector.LoadModules([]interfaces.Module{&core.Module{}})
+	connector.LoadModules([]interfaces.Module{&core.Module{Config:connector.config}})
+	connector.config = confer.NewConfig()
 
 	assert.Equal(t, 0, len(connector.GetHandlers()))
 	assert.Equal(t, 0, len(connector.GetIMHandlers()))
 
-	modules := []interfaces.Module{&core.Module{}}
+	modules := []interfaces.Module{&core.Module{Config:connector.config}}
 
 	connector.client = client.SimpleClient("phabulous")
 	connector.LoadModules(modules)

--- a/app/modules/core/command_lookup_test.go
+++ b/app/modules/core/command_lookup_test.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_additionalMatchersNil(t *testing.T) {
+	lookup_command := LookupCommand{AdditionalMatchers: nil}
+	assert.NotEmpty(t, lookup_command.GetMatchers())
+}
+
+func Test_additionalMatchers(t *testing.T) {
+	additionalMatchers := []string{"([D][0-9]{1,16})", "([D][0-1]{1,16})"}
+	lookupCommand := LookupCommand{AdditionalMatchers: additionalMatchers}
+	assert.Contains(t, lookupCommand.GetMatchers(), "([D][0-9]{1,16})")
+	assert.Contains(t, lookupCommand.GetMatchers(), "([D][0-1]{1,16})")
+}

--- a/app/modules/core/module.go
+++ b/app/modules/core/module.go
@@ -1,9 +1,14 @@
 package core
 
-import "github.com/etcinit/phabulous/app/interfaces"
+import (
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/jacobstr/confer"
+)
 
 // Module provides development/debugging commands.
-type Module struct{}
+type Module struct{
+	Config *confer.Config
+}
 
 // GetName returns the name of this module.
 func (m *Module) GetName() string {
@@ -12,8 +17,13 @@ func (m *Module) GetName() string {
 
 // GetCommands returns the commands provided by this module.
 func (m *Module) GetCommands() []interfaces.Command {
+	var lookupCommandAdditionalMatchers []string
+	if m.Config.InConfig("commands.lookup.matchers") {
+		lookupCommandAdditionalMatchers = m.Config.GetStringSlice("commands.lookup.matchers")
+	}
 	return []interfaces.Command{
-		&LookupCommand{},
+
+		&LookupCommand{AdditionalMatchers:lookupCommandAdditionalMatchers},
 		&SummonCommand{},
 		&MemeCommand{},
 		&ModulesCommand{},

--- a/app/modules/dev/module.go
+++ b/app/modules/dev/module.go
@@ -1,9 +1,14 @@
 package dev
 
-import "github.com/etcinit/phabulous/app/interfaces"
+import (
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/jacobstr/confer"
+)
 
 // Module provides development/debugging commands.
-type Module struct{}
+type Module struct{
+	Config *confer.Config
+}
 
 // GetName returns the name of this module.
 func (m *Module) GetName() string {

--- a/app/modules/extension/module.go
+++ b/app/modules/extension/module.go
@@ -1,9 +1,14 @@
 package extension
 
-import "github.com/etcinit/phabulous/app/interfaces"
+import (
+	"github.com/etcinit/phabulous/app/interfaces"
+	"github.com/jacobstr/confer"
+)
 
 // Module provides development/debugging commands.
-type Module struct{}
+type Module struct{
+	Config *confer.Config
+}
 
 // GetName returns the name of this module.
 func (m *Module) GetName() string {

--- a/app/modules/factory.go
+++ b/app/modules/factory.go
@@ -42,11 +42,11 @@ func (f *ModuleFactory) Make() []interfaces.Module {
 		}
 
 		if moduleName == "core" {
-			moduleMap["core"] = &core.Module{}
+			moduleMap["core"] = &core.Module{f.config}
 		} else if moduleName == "dev" {
-			moduleMap["dev"] = &dev.Module{}
+			moduleMap["dev"] = &dev.Module{f.config}
 		} else if moduleName == "extension" {
-			moduleMap["extension"] = &extension.Module{}
+			moduleMap["extension"] = &extension.Module{f.config}
 		} else {
 			f.logger.Panicf(
 				"Unable to load modules. Unknown module '%s'.",

--- a/app/modules/utilities/listutil.go
+++ b/app/modules/utilities/listutil.go
@@ -1,0 +1,32 @@
+package utilities
+
+func UniqueItemsOf(s []string) []string {
+	unique := make(map[string]bool, len(s))
+	uniques := make([]string, len(unique))
+	for _, elem := range s {
+		if len(elem) != 0 {
+			if !unique[elem] {
+				uniques = append(uniques, elem)
+				unique[elem] = true
+			}
+		}
+	}
+	return uniques
+}
+
+func Contains(slice1 []string, slice2 []string) bool {
+	slice1Uniques := UniqueItemsOf(slice1)
+	slice2Uniques := UniqueItemsOf(slice2)
+	for _, value2 := range slice2Uniques {
+		var slice2ItemInSlice1 = false
+		for _, value1 := range slice1Uniques {
+			if value1 == value2 {
+				slice2ItemInSlice1 = true
+			}
+		}
+		if !slice2ItemInSlice1 {
+			return false
+		}
+	}
+	return true
+}

--- a/config/main.yml
+++ b/config/main.yml
@@ -45,7 +45,7 @@ slack:
   # When set to false, the bot will post like any other integration (like
   # webhooks). This allows it to post on almost any channel without having to
   # be invited.
-  as-user: true
+  as-user: false
 irc:
   # Use this flag to enable/disable the IRC connector.
   enable: false
@@ -105,3 +105,9 @@ core:
     includeSelf: true
 misc:
   ignore-ca: false
+
+commands:
+  lookup:
+    # override set of REGEXes used by lookup commands
+    matchers:
+      - ([T|D][0-9]{1,16})+


### PR DESCRIPTION
POC:
 each module and command can parse the configuration and use
 the additional REGEXes specified in the config file.


There are few ways we could add this feature and I chose the 3rd option to keep things simple . I also wanted to keep the default behavior ( based on the suggestion from @schemar)
 1- duplicate the code in modules/core and then create new set of commands and then implement any REGEX we want.
 2- instead of returning []string each matcher could actually be a function which then can be overridden so that we can support both regex and non-regex matching
 3- let each command and module have access to the config or perhaps a subset of config which deals with commands. 

I could add same functionality to other modules and command if you think this approach makes sense.

<img width="957" alt="screen shot 2017-12-17 at 12 34 36 pm" src="https://user-images.githubusercontent.com/348681/34083513-d1a67f42-e326-11e7-8c28-9d2dbe138877.png">
