### PR TITLE
Add custom UnmarshalJSON methods for modified conduit api responses

### DIFF
--- a/vendor/github.com/etcinit/gonduit/entities/differential.go
+++ b/vendor/github.com/etcinit/gonduit/entities/differential.go
@@ -1,6 +1,9 @@
 package entities
 
-import "github.com/etcinit/gonduit/util"
+import (
+	"encoding/json"
+	"github.com/etcinit/gonduit/util"
+)
 
 // DifferentialRevision represents a revision in Differential.
 type DifferentialRevision struct {
@@ -25,4 +28,23 @@ type DifferentialRevision struct {
 	Hashes         [][]string          `json:"hashes"`
 	Auxiliary      map[string][]string `json:"auxiliary"`
 	RepositoryPHID string              `json:"repositoryPHID"`
+}
+
+func (dr *DifferentialRevision) UnmarshalJSON(data []byte) error {
+	type Alias DifferentialRevision
+	temp := &struct {
+		Reviewers map[string]string `json:"reviewers"`
+		*Alias
+	}{
+		Alias: (*Alias)(dr),
+	}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	for reviewer := range temp.Reviewers {
+		dr.Reviewers = append(dr.Reviewers, reviewer)
+	}
+
+	return nil
 }

--- a/vendor/github.com/etcinit/gonduit/requests/differential_query.go
+++ b/vendor/github.com/etcinit/gonduit/requests/differential_query.go
@@ -1,6 +1,9 @@
 package requests
 
-import "github.com/etcinit/gonduit/constants"
+import (
+	"github.com/etcinit/gonduit/constants"
+	"encoding/json"
+)
 
 // DifferentialQueryRequest represents a request to the
 // differential.query call.
@@ -20,4 +23,24 @@ type DifferentialQueryRequest struct {
 	ResponsibleUsers []string                         `json:"responsibleUsers"`
 	Branches         []string                         `json:"branches"`
 	Request
+}
+
+func (dqr *DifferentialQueryRequest) UnmarshalJSON(data []byte) error {
+	type Alias DifferentialQueryRequest
+	temp := &struct {
+		Reviewers map[string]string `json:"reviewers"`
+		*Alias
+	}{
+		Alias: (*Alias)(dqr),
+	}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	dqr.Reviewers = []string{}
+	for reviewer := range temp.Reviewers {
+		dqr.Reviewers = append(dqr.Reviewers, reviewer)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add custom UnmarshalJSON methods for DifferentialRevision and DifferentialQueryRequest to handle change in reviewers type from []string to map[string]string in conduit api.  Each value in the map is the same as the key, so we just need to read the keys